### PR TITLE
전조 로직 오류를 해결한다

### DIFF
--- a/src/main/java/model/Degree.java
+++ b/src/main/java/model/Degree.java
@@ -35,8 +35,13 @@ public class Degree {
 
     private void initializeNoteDisplayBasis(Note root) {
 
+        Note basis = root;
+        if (!basis.isPlain()) {
+            basis = getDisplayBasis(basis);
+        }
+
         int degreeNumber = 1;
-        NoteDisplayBasis degreeOneDisplayBasis = NoteDisplayBasis.from(root);
+        NoteDisplayBasis degreeOneDisplayBasis = NoteDisplayBasis.from(basis);
         degreeOneDisplayBasis.degreeNumber = new DegreeNumber(degreeNumber);
         degreeNumber++;
 
@@ -58,7 +63,30 @@ public class Degree {
         }
 
         throw new IllegalArgumentException(
-                this.getClass().getCanonicalName() + ": there's no note for given degree number for " + degreeNumber
+                this.getClass().getCanonicalName() + ": no suitable display basis for degree number of " + degreeNumber
         );
     }
+
+    public Note displayBasis(Note note) {
+
+        Note basis = note;
+        if (!basis.isPlain()) {
+            basis = getDisplayBasis(basis);
+        }
+
+        for (NoteDisplayBasis noteDisplayBasis : NoteDisplayBasis.values()) {
+            if (noteDisplayBasis.current.equals(basis)) {
+                return noteDisplayBasis.current;
+            }
+        }
+
+        throw new IllegalArgumentException(
+                this.getClass().getCanonicalName() + ": no suitable display basis for note of " + note
+        );
+    }
+
+    private Note getDisplayBasis(Note note) {
+        return NoteFactory.create(note.toString().substring(0, 1));
+    }
+
 }

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -31,10 +31,11 @@ public class Transposer {
         Note tranposedBass = interval.raise(transposeTo, semitones);
 
         DegreeNumber degreeNumber = interval.degree(semitones);
-        Note noteToFormat = degree.displayBasis(degreeNumber);
-
-        if (!tranposedBass.equals(noteToFormat)) {
-            tranposedBass = key.convertToSharpNoteOfSamePitch(tranposedBass, noteToFormat);
+        Note resultBasis1 = degree.displayBasis(tranposedBass);
+        Note resultBasis2 = degree.displayBasis(degreeNumber);
+        boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
+        if (needConvertToSharp) {
+            tranposedBass = key.convertToSharpNoteOfSamePitch(tranposedBass, resultBasis2);
         }
 
         return new Chord(tranposedBass.toString() + chord.getChordTones());

--- a/src/test/java/unit/service/chord/TransposerTest.java
+++ b/src/test/java/unit/service/chord/TransposerTest.java
@@ -6,28 +6,41 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import model.Chord;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import service.chord.Transposer;
 
 class TransposerTest {
 
+    List<Chord> notesInBflatKey;
+    List<Chord> notesInAKey;
+
+    @BeforeEach
+    public void setUp() {
+
+        notesInBflatKey = List.of("Bb", "C", "D", "Eb", "F", "G", "A")
+                              .stream()
+                              .map(Chord::new)
+                              .collect(Collectors.toList());
+
+        notesInAKey = List.of("A", "B", "C#", "D", "E", "F#", "G#")
+                          .stream()
+                          .map(Chord::new)
+                          .collect(Collectors.toList());
+    }
+
     @Test
     public void transposeFromFlatToPlain() {
+
         Transposer transposer = new Transposer("Bb", "A");
-        List<Chord> chords = List.of("Bb", "C", "D", "Eb", "F", "G", "A")
-                                 .stream()
-                                 .map(Chord::new)
-                                 .collect(Collectors.toList());
+        List<Chord> chords = notesInBflatKey;
 
         List<Chord> transposed = new ArrayList<>();
         for (Chord chord : chords) {
             transposed.add(transposer.doTranspose(chord));
         }
 
-        List<Chord> expected = List.of("A", "B", "C#", "D", "E", "F#", "G#")
-                                   .stream()
-                                   .map(Chord::new)
-                                   .collect(Collectors.toList());
+        List<Chord> expected = notesInAKey;
 
         for (int i = 0; i < transposed.size(); i++) {
             assertThat(transposed.get(i)).isEqualTo(expected.get(i));
@@ -36,21 +49,16 @@ class TransposerTest {
 
     @Test
     public void transposeFromPlainToFlat() {
+
         Transposer transposer = new Transposer("A", "Bb");
-        List<Chord> chords = List.of("A", "B", "C#", "D", "E", "F#", "G#")
-                                 .stream()
-                                 .map(Chord::new)
-                                 .collect(Collectors.toList());
+        List<Chord> chords = notesInAKey;
 
         List<Chord> transposed = new ArrayList<>();
         for (Chord chord : chords) {
             transposed.add(transposer.doTranspose(chord));
         }
 
-        List<Chord> expected = List.of("Bb", "C", "D", "Eb", "F", "G", "A")
-                                   .stream()
-                                   .map(Chord::new)
-                                   .collect(Collectors.toList());
+        List<Chord> expected = notesInBflatKey;
 
         for (int i = 0; i < transposed.size(); i++) {
             assertThat(transposed.get(i)).isEqualTo(expected.get(i));

--- a/src/test/java/unit/service/chord/TransposerTest.java
+++ b/src/test/java/unit/service/chord/TransposerTest.java
@@ -28,4 +28,13 @@ class TransposerTest {
         Assertions.assertThat(transposed).isEqualTo(new Chord("E7"));
     }
 
+    @Test
+    public void t() {
+        Transposer transposer = new Transposer("A", "Bb");
+
+        Chord transposed = transposer.doTranspose(new Chord("A"));
+        Chord expected = new Chord("Bb");
+
+        Assertions.assertThat(transposed).isEqualTo(expected);
+    }
 }

--- a/src/test/java/unit/service/chord/TransposerTest.java
+++ b/src/test/java/unit/service/chord/TransposerTest.java
@@ -1,40 +1,59 @@
 package unit.service.chord;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import model.Chord;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import service.chord.Transposer;
 
 class TransposerTest {
 
     @Test
-    public void transposeMajorChord() {
-        Transposer transposer = new Transposer("G", "A");
-        Chord transposed = transposer.doTranspose(new Chord("G"));
-        Assertions.assertThat(transposed).isEqualTo(new Chord("A"));
+    public void transposeFromFlatToPlain() {
+        Transposer transposer = new Transposer("Bb", "A");
+        List<Chord> chords = List.of("Bb", "C", "D", "Eb", "F", "G", "A")
+                                 .stream()
+                                 .map(Chord::new)
+                                 .collect(Collectors.toList());
+
+        List<Chord> transposed = new ArrayList<>();
+        for (Chord chord : chords) {
+            transposed.add(transposer.doTranspose(chord));
+        }
+
+        List<Chord> expected = List.of("A", "B", "C#", "D", "E", "F#", "G#")
+                                   .stream()
+                                   .map(Chord::new)
+                                   .collect(Collectors.toList());
+
+        for (int i = 0; i < transposed.size(); i++) {
+            assertThat(transposed.get(i)).isEqualTo(expected.get(i));
+        }
     }
 
     @Test
-    public void transposeMinorChord() {
-        Transposer transposer = new Transposer("G", "A");
-        Chord transposed = transposer.doTranspose(new Chord("Bm"));
-        Assertions.assertThat(transposed).isEqualTo(new Chord("C#m"));
-    }
-
-    @Test
-    public void transpose7thChord() {
-        Transposer transposer = new Transposer("G", "A");
-        Chord transposed = transposer.doTranspose(new Chord("D7"));
-        Assertions.assertThat(transposed).isEqualTo(new Chord("E7"));
-    }
-
-    @Test
-    public void t() {
+    public void transposeFromPlainToFlat() {
         Transposer transposer = new Transposer("A", "Bb");
+        List<Chord> chords = List.of("A", "B", "C#", "D", "E", "F#", "G#")
+                                 .stream()
+                                 .map(Chord::new)
+                                 .collect(Collectors.toList());
 
-        Chord transposed = transposer.doTranspose(new Chord("A"));
-        Chord expected = new Chord("Bb");
+        List<Chord> transposed = new ArrayList<>();
+        for (Chord chord : chords) {
+            transposed.add(transposer.doTranspose(chord));
+        }
 
-        Assertions.assertThat(transposed).isEqualTo(expected);
+        List<Chord> expected = List.of("Bb", "C", "D", "Eb", "F", "G", "A")
+                                   .stream()
+                                   .map(Chord::new)
+                                   .collect(Collectors.toList());
+
+        for (int i = 0; i < transposed.size(); i++) {
+            assertThat(transposed.get(i)).isEqualTo(expected.get(i));
+        }
     }
 }


### PR DESCRIPTION
#### 작업 내용
- 기존 구현의 전조 로직 오류를 해결했다.
- 재발을 방지하기 위해, 테스트 메서드 하나에서 더 많은 케이스를 테스트할 수 있도록 바꿨다. 케이스는 많아졌지만, 한 메서드 내부의 케이스는 전조 전 키와 전조 전 키 쌍이 동일한 케이스로만 구성되어 일관성을 갖는다.

#### 연관 이슈(ex. #x)
- #1 
