### PR TITLE
테스트 패키지 구성을 되돌린다

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/src/test/java/model/ChordTest.java
+++ b/src/test/java/model/ChordTest.java
@@ -1,8 +1,7 @@
-package unit.model;
+package model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import model.Chord;
 import org.junit.jupiter.api.Test;
 
 class ChordTest {

--- a/src/test/java/model/DegreeTest.java
+++ b/src/test/java/model/DegreeTest.java
@@ -1,9 +1,5 @@
-package unit.model;
+package model;
 
-import model.Degree;
-import model.DegreeNumber;
-import model.Interval;
-import model.SemitoneCount;
 import model.note.Note;
 import model.note.NoteFactory;
 import org.assertj.core.api.Assertions;

--- a/src/test/java/model/IntervalTest.java
+++ b/src/test/java/model/IntervalTest.java
@@ -1,10 +1,7 @@
-package unit.model;
+package model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import model.DegreeNumber;
-import model.Interval;
-import model.SemitoneCount;
 import model.note.Note;
 import model.note.NoteFactory;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/model/KeyTest.java
+++ b/src/test/java/model/KeyTest.java
@@ -1,8 +1,7 @@
-package unit.model;
+package model;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import model.Key;
 import model.note.Note;
 import model.note.NoteFactory;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/model/note/NoteTest.java
+++ b/src/test/java/model/note/NoteTest.java
@@ -1,6 +1,5 @@
-package unit.model.note;
+package model.note;
 
-import model.note.NoteFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/service/TransposeServiceIntegrationTest.java
+++ b/src/test/java/service/TransposeServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package integration.service;
+package service;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -7,7 +7,6 @@ import model.Line;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import service.TransposeService;
 import service.chord.Transposer;
 import service.file.FileHandlerFactory;
 import service.line.LineParser;

--- a/src/test/java/service/TransposeServiceTest.java
+++ b/src/test/java/service/TransposeServiceTest.java
@@ -1,4 +1,4 @@
-package unit.service;
+package service;
 
 import static org.mockito.Mockito.when;
 
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import service.TransposeService;
 import service.file.DefaultFileHandler;
 import service.line.Parser;
 

--- a/src/test/java/service/chord/TransposerTest.java
+++ b/src/test/java/service/chord/TransposerTest.java
@@ -1,4 +1,4 @@
-package unit.service.chord;
+package service.chord;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import model.Chord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import service.chord.Transposer;
 
 class TransposerTest {
 

--- a/src/test/java/service/file/FileHandlerTest.java
+++ b/src/test/java/service/file/FileHandlerTest.java
@@ -1,4 +1,4 @@
-package unit.service.file;
+package service.file;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -9,8 +9,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import service.file.DefaultFileHandler;
-import service.file.FileHandlerFactory;
 
 class FileHandlerTest {
 

--- a/src/test/java/service/line/LineParserIntegrationTest.java
+++ b/src/test/java/service/line/LineParserIntegrationTest.java
@@ -1,4 +1,4 @@
-package integration.service.line;
+package service.line;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,7 +9,6 @@ import model.Chord;
 import model.Line;
 import org.junit.jupiter.api.Test;
 import service.chord.Transposer;
-import service.line.LineParser;
 
 public class LineParserIntegrationTest {
 


### PR DESCRIPTION
#### 작업 내용
- 기존에 단위/통합/E2E 테스트별로 패키지를 나눈 방식을 도입했는데, 관리에 불편함이 있고 현재 상황에서 큰 이득을 얻지 못해 되돌린다.

#### 연관 이슈(ex. #x)
- X
