### PR TITLE
Transposer의 책임을 다른 도메인 모델로 옮긴다

### DIFF
--- a/src/main/java/model/Degree.java
+++ b/src/main/java/model/Degree.java
@@ -54,11 +54,11 @@ public class Degree {
         }
     }
 
-    public Note displayBasis(DegreeNumber degreeNumber) {
+    private NoteDisplayBasis displayBasis(DegreeNumber degreeNumber) {
 
         for (NoteDisplayBasis noteDisplayBasis : NoteDisplayBasis.values()) {
             if (noteDisplayBasis.degreeNumber.equals(degreeNumber)) {
-                return noteDisplayBasis.current;
+                return noteDisplayBasis;
             }
         }
 
@@ -67,7 +67,7 @@ public class Degree {
         );
     }
 
-    public Note displayBasis(Note note) {
+    private NoteDisplayBasis displayBasis(Note note) {
 
         Note basis = note;
         if (!basis.isPlain()) {
@@ -76,7 +76,7 @@ public class Degree {
 
         for (NoteDisplayBasis noteDisplayBasis : NoteDisplayBasis.values()) {
             if (noteDisplayBasis.current.equals(basis)) {
-                return noteDisplayBasis.current;
+                return noteDisplayBasis;
             }
         }
 
@@ -85,8 +85,27 @@ public class Degree {
         );
     }
 
+    public Note displayBasisNote(DegreeNumber degreeNumber) {
+
+        for (NoteDisplayBasis noteDisplayBasis : NoteDisplayBasis.values()) {
+            if (noteDisplayBasis.degreeNumber.equals(degreeNumber)) {
+                return noteDisplayBasis.current;
+            }
+        }
+
+        throw new IllegalArgumentException(
+                this.getClass().getCanonicalName()
+                        + ": no suitable note representing display basis for degree number of " + degreeNumber
+        );
+    }
+
     private Note getDisplayBasis(Note note) {
         return NoteFactory.create(note.toString().substring(0, 1));
     }
 
+    public boolean compareDisplayBasis(Note note, DegreeNumber degreenumber) {
+        NoteDisplayBasis displaybasis1 = this.displayBasis(note);
+        NoteDisplayBasis displaybasis2 = this.displayBasis(degreenumber);
+        return displaybasis1.equals(displaybasis2);
+    }
 }

--- a/src/main/java/model/Key.java
+++ b/src/main/java/model/Key.java
@@ -53,4 +53,16 @@ public class Key {
 
         return EquivalentNoteFinder.findEquivalentNoteMeetsFormat(note, basis);
     }
+
+    public SemitoneCount semitones(Note base, Note target) {
+        return this.interval.semitones(base, target);
+    }
+
+    public Note raise(Note base, SemitoneCount target) {
+        return this.interval.raise(base, target);
+    }
+
+    public DegreeNumber degree(SemitoneCount semitones) {
+        return this.interval.degree(semitones);
+    }
 }

--- a/src/main/java/model/Key.java
+++ b/src/main/java/model/Key.java
@@ -54,12 +54,12 @@ public class Key {
         Note resultBasis2 = degree.displayBasis(degreeNumber);
         boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
         if (needConvertToSharp) {
-            note = this.convertToSharpNoteOfSamePitch(note, resultBasis2);
+            note = this.convertToSharp(note, resultBasis2);
         }
         return note;
     }
 
-    public Note convertToSharpNoteOfSamePitch(Note note, Note basis) {
+    public Note convertToSharp(Note note, Note basis) {
 
         return EquivalentNoteFinder.findEquivalentNoteMeetsFormat(note, basis);
     }

--- a/src/main/java/model/Key.java
+++ b/src/main/java/model/Key.java
@@ -50,13 +50,16 @@ public class Key {
     }
 
     public Note format(Note note, DegreeNumber degreeNumber, Degree degree) {
-        Note resultBasis1 = degree.displayBasis(note);
-        Note resultBasis2 = degree.displayBasis(degreeNumber);
-        boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
+
+        Note result = note;
+
+        boolean needConvertToSharp = !degree.compareDisplayBasis(note, degreeNumber);
         if (needConvertToSharp) {
-            note = this.convertToSharp(note, resultBasis2);
+            Note resultBasis = degree.displayBasisNote(degreeNumber);
+            result = this.convertToSharp(note, resultBasis);
         }
-        return note;
+
+        return result;
     }
 
     public Note convertToSharp(Note note, Note basis) {

--- a/src/main/java/model/Key.java
+++ b/src/main/java/model/Key.java
@@ -67,12 +67,12 @@ public class Key {
         return EquivalentNoteFinder.findEquivalentNoteMeetsFormat(note, basis);
     }
 
-    public SemitoneCount semitones(Note base, Note target) {
-        return this.interval.semitones(base, target);
+    public SemitoneCount semitones(Note target) {
+        return this.interval.semitones(this.rootNote, target);
     }
 
-    public Note raise(Note base, SemitoneCount target) {
-        return this.interval.raise(base, target);
+    public Note raise(SemitoneCount target) {
+        return this.interval.raise(this.rootNote, target);
     }
 
     public DegreeNumber degree(SemitoneCount semitones) {

--- a/src/main/java/model/Key.java
+++ b/src/main/java/model/Key.java
@@ -49,6 +49,16 @@ public class Key {
         this.interval = new Interval();
     }
 
+    public Note format(Note note, DegreeNumber degreeNumber, Degree degree) {
+        Note resultBasis1 = degree.displayBasis(note);
+        Note resultBasis2 = degree.displayBasis(degreeNumber);
+        boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
+        if (needConvertToSharp) {
+            note = this.convertToSharpNoteOfSamePitch(note, resultBasis2);
+        }
+        return note;
+    }
+
     public Note convertToSharpNoteOfSamePitch(Note note, Note basis) {
 
         return EquivalentNoteFinder.findEquivalentNoteMeetsFormat(note, basis);

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -11,31 +11,32 @@ import model.note.NoteFactory;
 
 public class Transposer {
 
-    private final Note currentKey;
-    private final Note transposeTo;
+    private final Note currentRoot;
+    private final Note transposedRoot;
     private final Degree degree;
-    private final Key key;
+    private final Key transposedKey;
 
-    public Transposer(String currentKey, String transposeTo) {
-        this.currentKey = NoteFactory.create(currentKey);
-        this.transposeTo = NoteFactory.create(transposeTo);
-        this.degree = new Degree(this.transposeTo);
-        this.key = new Key(this.transposeTo);
+    public Transposer(String currentRoot, String transposedRoot) {
+        this.currentRoot = NoteFactory.create(currentRoot);
+        this.transposedRoot = NoteFactory.create(transposedRoot);
+        this.degree = new Degree(this.transposedRoot);
+        this.transposedKey = new Key(this.transposedRoot);
     }
 
     public Chord doTranspose(Chord chord) {
         Note currentBass = NoteFactory.create(chord.getRootNote());
 
         Interval interval = new Interval();
-        SemitoneCount semitones = interval.semitones(currentKey, currentBass);
-        Note tranposedBass = interval.raise(transposeTo, semitones);
+        SemitoneCount semitones = interval.semitones(currentRoot, currentBass);
 
+        Note tranposedBass = interval.raise(transposedRoot, semitones);
         DegreeNumber degreeNumber = interval.degree(semitones);
+
         Note resultBasis1 = degree.displayBasis(tranposedBass);
         Note resultBasis2 = degree.displayBasis(degreeNumber);
         boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
         if (needConvertToSharp) {
-            tranposedBass = key.convertToSharpNoteOfSamePitch(tranposedBass, resultBasis2);
+            tranposedBass = transposedKey.convertToSharpNoteOfSamePitch(tranposedBass, resultBasis2);
         }
 
         return new Chord(tranposedBass.toString() + chord.getChordTones());

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -31,13 +31,8 @@ public class Transposer {
         Note transposedBass = currentKey.raise(transposedRoot, semitones);
         DegreeNumber degreeNumber =  currentKey.degree(semitones);
 
-        Note resultBasis1 = degree.displayBasis(transposedBass);
-        Note resultBasis2 = degree.displayBasis(degreeNumber);
-        boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
-        if (needConvertToSharp) {
-            transposedBass = transposedKey.convertToSharpNoteOfSamePitch(transposedBass, resultBasis2);
-        }
+        Note resultBass = transposedKey.format(transposedBass, degreeNumber, degree);
 
-        return new Chord(transposedBass.toString() + chord.getChordTones());
+        return new Chord(resultBass.toString() + chord.getChordTones());
     }
 }

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -3,7 +3,6 @@ package service.chord;
 import model.Chord;
 import model.Degree;
 import model.DegreeNumber;
-import model.Interval;
 import model.Key;
 import model.SemitoneCount;
 import model.note.Note;
@@ -28,11 +27,9 @@ public class Transposer {
     public Chord doTranspose(Chord chord) {
         Note currentBass = NoteFactory.create(chord.getRootNote());
 
-        Interval interval = new Interval();
-        SemitoneCount semitones = interval.semitones(currentRoot, currentBass);
-
-        Note tranposedBass = interval.raise(transposedRoot, semitones);
-        DegreeNumber degreeNumber = interval.degree(semitones);
+        SemitoneCount semitones = currentKey.semitones(currentRoot, currentBass);
+        Note tranposedBass = currentKey.raise(transposedRoot, semitones);
+        DegreeNumber degreeNumber =  currentKey.degree(semitones);
 
         Note resultBasis1 = degree.displayBasis(tranposedBass);
         Note resultBasis2 = degree.displayBasis(degreeNumber);

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -28,16 +28,16 @@ public class Transposer {
         Note currentBass = NoteFactory.create(chord.getRootNote());
 
         SemitoneCount semitones = currentKey.semitones(currentRoot, currentBass);
-        Note tranposedBass = currentKey.raise(transposedRoot, semitones);
+        Note transposedBass = currentKey.raise(transposedRoot, semitones);
         DegreeNumber degreeNumber =  currentKey.degree(semitones);
 
-        Note resultBasis1 = degree.displayBasis(tranposedBass);
+        Note resultBasis1 = degree.displayBasis(transposedBass);
         Note resultBasis2 = degree.displayBasis(degreeNumber);
         boolean needConvertToSharp = !resultBasis1.equals(resultBasis2);
         if (needConvertToSharp) {
-            tranposedBass = transposedKey.convertToSharpNoteOfSamePitch(tranposedBass, resultBasis2);
+            transposedBass = transposedKey.convertToSharpNoteOfSamePitch(transposedBass, resultBasis2);
         }
 
-        return new Chord(tranposedBass.toString() + chord.getChordTones());
+        return new Chord(transposedBass.toString() + chord.getChordTones());
     }
 }

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -10,25 +10,21 @@ import model.note.NoteFactory;
 
 public class Transposer {
 
-    private final Note currentRoot;
-    private final Note transposedRoot;
     private final Degree degree;
     private final Key currentKey;
     private final Key transposedKey;
 
     public Transposer(String currentRoot, String transposedRoot) {
-        this.currentRoot = NoteFactory.create(currentRoot);
-        this.transposedRoot = NoteFactory.create(transposedRoot);
-        this.degree = new Degree(this.transposedRoot);
-        this.currentKey = new Key(this.currentRoot);
-        this.transposedKey = new Key(this.transposedRoot);
+        this.degree = new Degree(NoteFactory.create(transposedRoot));
+        this.currentKey = new Key(NoteFactory.create(currentRoot));
+        this.transposedKey = new Key(NoteFactory.create(transposedRoot));
     }
 
     public Chord doTranspose(Chord chord) {
         Note currentBass = NoteFactory.create(chord.getRootNote());
 
-        SemitoneCount semitones = currentKey.semitones(currentRoot, currentBass);
-        Note transposedBass = currentKey.raise(transposedRoot, semitones);
+        SemitoneCount semitones = currentKey.semitones(currentBass);
+        Note transposedBass = transposedKey.raise(semitones);
         DegreeNumber degreeNumber =  currentKey.degree(semitones);
 
         Note resultBass = transposedKey.format(transposedBass, degreeNumber, degree);

--- a/src/main/java/service/chord/Transposer.java
+++ b/src/main/java/service/chord/Transposer.java
@@ -14,12 +14,14 @@ public class Transposer {
     private final Note currentRoot;
     private final Note transposedRoot;
     private final Degree degree;
+    private final Key currentKey;
     private final Key transposedKey;
 
     public Transposer(String currentRoot, String transposedRoot) {
         this.currentRoot = NoteFactory.create(currentRoot);
         this.transposedRoot = NoteFactory.create(transposedRoot);
         this.degree = new Degree(this.transposedRoot);
+        this.currentKey = new Key(this.currentRoot);
         this.transposedKey = new Key(this.transposedRoot);
     }
 

--- a/src/test/java/model/DegreeTest.java
+++ b/src/test/java/model/DegreeTest.java
@@ -11,7 +11,7 @@ class DegreeTest {
     public void getNoteForDegree() {
         Note noteD = NoteFactory.create("D");
         Degree degree = new Degree(noteD);
-        Assertions.assertThat(degree.displayBasis(new DegreeNumber(2)).toString()).isEqualTo("E");
+        Assertions.assertThat(degree.displayBasisNote(new DegreeNumber(2)).toString()).isEqualTo("E");
     }
 
     @Test
@@ -25,7 +25,7 @@ class DegreeTest {
         DegreeNumber degreeOfInterval = itv.degree(interval);
 
         Degree degree = new Degree(keyAfter);
-        Note noteToFormat = degree.displayBasis(degreeOfInterval);
+        Note noteToFormat = degree.displayBasisNote(degreeOfInterval);
         Assertions.assertThat(noteToFormat.toString()).isEqualTo("F");
     }
 }

--- a/src/test/java/model/KeyTest.java
+++ b/src/test/java/model/KeyTest.java
@@ -11,7 +11,7 @@ public class KeyTest {
     @Test
     public void formatFlatNote() {
         Key k = new Key(NoteFactory.create("D"));
-        Note formatted = k.convertToSharpNoteOfSamePitch(NoteFactory.create("Gb"), NoteFactory.create("F"));
+        Note formatted = k.convertToSharp(NoteFactory.create("Gb"), NoteFactory.create("F"));
         assertThat(formatted).isEqualTo(NoteFactory.create("F#"));
     }
 }


### PR DESCRIPTION
#### 작업 내용
- 기존 구현에서 각각의 객체가 맡는 역할과 책임이 적절한지를 고민하고 수정했다.
- Transposer.doTransposer() 내부 Interval 인스턴스가 가진 책임을 Key로 옮겼다.
- 메서드 이름에 맞게 반환 타입을 바꾸면서(Note->NoteDisplayBasis), 접근 권한 문제로 해당 메서드를 Degree 안에서만 쓰도록 하고, 외부에 노출할 메서드를 새로 만들었다.

#### 연관 이슈(ex. #x)
- X
